### PR TITLE
Lotto 38 name_game in urls

### DIFF
--- a/lotto_app/app/parsers/parser_90_numbers.py
+++ b/lotto_app/app/parsers/parser_90_numbers.py
@@ -43,9 +43,10 @@ class Parser90Numbers(LottoParser):
         game_id = re.search(r'№\d{3,4},', game_tags.text)[0].replace('№', '').replace(',', '')
         self.validate_game(game_id)
 
-        no_number_tags = self.soup.find('div', class_='drawing_win_numbers barrels').find_all('li')
-        str_no_numbers = ''.join([tag.text for tag in no_number_tags])
-        self._validate_no_number(str_no_numbers, str_numbers)
+        if (len(str_numbers) != 180):
+            no_number_tags = self.soup.find('div', class_='drawing_win_numbers barrels').find_all('li')
+            str_no_numbers = ''.join([tag.text for tag in no_number_tags])
+            self._validate_no_number(str_no_numbers, str_numbers)
 
         return {'str_numbers': str_numbers,
                 'last_win_number_card': dirty_numbers[1][-2:],

--- a/lotto_app/app/utils.py
+++ b/lotto_app/app/utils.py
@@ -90,10 +90,7 @@ def get_game_info(game_obj, mult=None):
     numbers = game_obj.numbers
     cost_numbers = get_cost_numbers(numbers, mult)
 
-    return {'numbers': numbers,
-            'first_line_6': [int(n) for n in numbers[0:6]],
-            'first_line_15': [int(n) for n in numbers[0:15]],
-            'cost_numbers': cost_numbers,
+    return {'cost_numbers': cost_numbers,
             'bingo_30': get_bingo_30(numbers)
             }
 

--- a/lotto_app/app/views/games.py
+++ b/lotto_app/app/views/games.py
@@ -43,8 +43,6 @@ class GameViewSet(viewsets.ModelViewSet):
             'min_cost': str_total_cost_numbers[0],
             'max_cost': str_total_cost_numbers[89],
             'total_cost_numbers': total_cost_numbers,
-            'total_index_bingo_30': index_bingo(total_cost_numbers,
-                                                [num for num in list(total_cost_numbers.keys())[0:30]]),
         }
 
     @action(detail=True, url_path='info', methods=['get'])
@@ -54,10 +52,10 @@ class GameViewSet(viewsets.ModelViewSet):
         factor_games = get_factor_games(1)
         return Response(get_game_info(game_obj, factor_games[0]), status=200)
 
-    @action(detail=False, url_path='last_games_info', methods=['get'])
-    def last_games_info(self, request):
-        print('last_games_info/')
-        game_id = request.query_params.get('game_id')
+    @action(detail=True, url_path='several_games_info', methods=['get'])
+    def several_games_info(self, request, ng, pk):
+        print('several_games_info/')
+        game_id, game_obj = self.game_request()
         return Response(self.get_several_games_info(game_id), status=200)
 
     def _condition_numbers(self, previous_games, current_game, condition):
@@ -80,7 +78,7 @@ class GameViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, url_path='future_game_30', methods=['get'])
     def future_game_30(self, request, ng, pk):
-        print('index_bingo_30/')
+        print('future_game_30/')
         game_id, game_obj = self.game_request()
         total_cost_numbers = self.get_several_games_info(game_id)['total_cost_numbers']
         game_info = get_game_info(game_obj)

--- a/lotto_app/app/views/games.py
+++ b/lotto_app/app/views/games.py
@@ -18,9 +18,9 @@ class GameViewSet(viewsets.ModelViewSet):
     def get_object(self):
         return Game.objects.get(name_game=self.kwargs['ng'], game_id=self.kwargs['pk'])
 
-    def game_request(self, request):
-        game_id = request.query_params.get('game_id')
-        return game_id, Game.objects.get(game_id=game_id)
+    def game_request(self):
+        game_id = self.kwargs['pk']
+        return game_id, Game.objects.get(name_game=self.kwargs['ng'], game_id=game_id)
 
     @staticmethod
     def get_last_games_info(game_id):
@@ -46,10 +46,10 @@ class GameViewSet(viewsets.ModelViewSet):
                                                 [num for num in list(total_cost_numbers.keys())[0:30]])
         }
 
-    @action(detail=False, url_path='info', methods=['get'])
-    def info(self, request):
+    @action(detail=True, url_path='info', methods=['get'])
+    def info(self, request, ng, pk):
         print('info/')
-        game_id, game_obj = self.game_request(request)
+        game_id, game_obj = self.game_request()
         return Response(get_game_info(game_obj), status=200)
 
     @action(detail=False, url_path='last_games_info', methods=['get'])

--- a/lotto_app/app/views/games.py
+++ b/lotto_app/app/views/games.py
@@ -45,6 +45,11 @@ class GameViewSet(viewsets.ModelViewSet):
             'total_cost_numbers': total_cost_numbers,
         }
 
+    @staticmethod
+    def get_several_games_no_numbers(total_cost_numbers, game_info):
+        return {num: total_cost_numbers[int(num)] for num, v in game_info['cost_numbers'].items() if
+                v == 0}
+
     @action(detail=True, url_path='info', methods=['get'])
     def info(self, request, ng, pk):
         print('info/')

--- a/lotto_app/app/views/games.py
+++ b/lotto_app/app/views/games.py
@@ -97,9 +97,9 @@ class GameViewSet(viewsets.ModelViewSet):
         return Response(indexes, status=200)
 
     @action(detail=False, url_path='parsers', methods=['post'])
-    def parsers(self, request):
+    def parsers(self, request, ng):
         print('parsers/')
-        name_game = request.data['name_game']
+        name_game = ng
         page = request.data['page']
         class_parser = ChoiseParsers(name_game, page).get_class_parser()
         serializer = self.get_serializer(data=class_parser.parser_response_for_view())
@@ -109,9 +109,9 @@ class GameViewSet(viewsets.ModelViewSet):
         return Response(serializer.data, status=201, headers=headers)
 
     @action(detail=False, url_path='parsers_mult_pages', methods=['post'])
-    def parsers_mult_pages(self, request):
+    def parsers_mult_pages(self, request, ng):
         print('parsers_mult_pages/')
-        name_game = request.data['name_game']
+        name_game = ng
         page_start = request.data['page_start']
         page_end = request.data['page_end']
         list_serializers = []

--- a/lotto_app/app/views/value_previous_games.py
+++ b/lotto_app/app/views/value_previous_games.py
@@ -1,0 +1,34 @@
+from rest_framework import viewsets
+from rest_framework.response import Response
+
+from lotto_app.app.models import Game
+from lotto_app.app.utils import get_game_info
+
+
+class ValuePreviousGamesViewSet(viewsets.ModelViewSet):
+
+    @staticmethod
+    def value_previous_games(name_game, how_numbers, previous_games, current_game):
+        value_previous_games = {i: 0 for i in range(1, 91)}
+        number_info = []
+
+        game_objs = Game.objects.filter(
+            name_game=name_game,
+            game_id__in=[g for g in range(current_game - previous_games + 1, current_game + 1)])
+        for game_obj in game_objs:
+            if not how_numbers:
+                how_numbers = game_obj.get_win_ticket()['by_account']
+            number_info.append(get_game_info(game_obj)['numbers'][:int(how_numbers)])
+
+        for _info in number_info:
+            for num in _info:
+                value_previous_games[num] += 1
+        return value_previous_games
+
+    def retrieve(self, request, *args, **kwargs):
+        name_game = self.kwargs['ng']
+        how_numbers = request.query_params.get('how_numbers', None)
+        previous_games = int(request.query_params.get('previous_games'))
+        current_game = int(self.kwargs['pk'])
+        return Response(self.value_previous_games(name_game, how_numbers, previous_games, current_game),
+                        status=200)

--- a/lotto_app/app/views/value_previous_games.py
+++ b/lotto_app/app/views/value_previous_games.py
@@ -2,7 +2,6 @@ from rest_framework import viewsets
 from rest_framework.response import Response
 
 from lotto_app.app.models import Game
-from lotto_app.app.utils import get_game_info
 
 
 class ValuePreviousGamesViewSet(viewsets.ModelViewSet):
@@ -18,7 +17,7 @@ class ValuePreviousGamesViewSet(viewsets.ModelViewSet):
         for game_obj in game_objs:
             if not how_numbers:
                 how_numbers = game_obj.get_win_ticket()['by_account']
-            number_info.append(get_game_info(game_obj)['numbers'][:int(how_numbers)])
+            number_info.append(game_obj.numbers[:int(how_numbers)])
 
         for _info in number_info:
             for num in _info:

--- a/lotto_app/urls.py
+++ b/lotto_app/urls.py
@@ -14,7 +14,7 @@ router = DefaultRouter()
 router.register(r'users', UserViewSet)
 router.register(r'groups', GroupViewSet)
 
-router.register(r'', GameViewSet, basename='game')
+router.register(r'game', GameViewSet, basename='game')
 
 router.register(r'value_previous_games', ValuePreviousGamesViewSet, basename='value_previous_games')
 
@@ -29,6 +29,6 @@ router.register(r'lotto_tickets', LottoTicketsViewSet, basename='lotto_tickets')
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
-    path(r'game/<str:ng>/', include(router.urls)),
-    path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+    path(r'<str:ng>/', include(router.urls)),
+    path(r'<str:ng>/api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]

--- a/lotto_app/urls.py
+++ b/lotto_app/urls.py
@@ -1,5 +1,5 @@
 from django.urls import include, path
-from django.urls import re_path as url
+# from django.urls import re_path as url
 from rest_framework.routers import DefaultRouter
 
 from lotto_app.app.views.games import GameViewSet
@@ -8,12 +8,16 @@ from lotto_app.app.views.pc_choice import PcChoiceViewSet
 from lotto_app.app.views.researchs import ResearchViewSet
 from lotto_app.app.views.state_tickets import StateNumbersViewSet
 from lotto_app.app.views.users import GroupViewSet, UserViewSet
+from lotto_app.app.views.value_previous_games import ValuePreviousGamesViewSet
 
 router = DefaultRouter()
 router.register(r'users', UserViewSet)
 router.register(r'groups', GroupViewSet)
 
-router.register(r'game', GameViewSet, basename='game')
+router.register(r'', GameViewSet, basename='game')
+
+router.register(r'value_previous_games', ValuePreviousGamesViewSet, basename='value_previous_games')
+
 router.register(r'state_numbers', StateNumbersViewSet, basename='state_numbers')
 
 router.register(r'pc_choice', PcChoiceViewSet, basename='pc_choice')
@@ -25,6 +29,6 @@ router.register(r'lotto_tickets', LottoTicketsViewSet, basename='lotto_tickets')
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
-    url('', include(router.urls)),
+    path(r'game/<str:ng>/', include(router.urls)),
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]

--- a/scripts/lotto-38_fix_name_game_study.py
+++ b/scripts/lotto-38_fix_name_game_study.py
@@ -1,0 +1,8 @@
+from lotto_app.app.models import Game
+
+
+def fix_name_game_study():
+    study_objs = [obj for obj in Game.objects.all() if int(obj.game_id) < 700]
+    for game_obj in study_objs:
+        game_obj.name_game = "study"
+        game_obj.save(update_fields=['name_game'])

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,7 +2,6 @@ from random import shuffle
 
 from lotto_app.app.models import Game
 
-
 """
 Default win_card and win_ticket of the GameFactory class:
 

--- a/tests/test_app/view/game/test_game.py
+++ b/tests/test_app/view/game/test_game.py
@@ -5,7 +5,7 @@ from tests.helpers import GameFactory
 
 
 class GameTestApiCase(WebTest):
-    endpoint = '/game/'
+    endpoint = '/game/test_lotto1/'
 
     def setUp(self):
         super(GameTestApiCase, self).setUp()

--- a/tests/test_app/view/game/test_game.py
+++ b/tests/test_app/view/game/test_game.py
@@ -5,7 +5,7 @@ from tests.helpers import GameFactory
 
 
 class GameTestApiCase(WebTest):
-    endpoint = '/game/test_lotto1/'
+    endpoint = '/test_lotto1/game/'
 
     def setUp(self):
         super(GameTestApiCase, self).setUp()

--- a/tests/test_app/view/game/test_value_previous_games.py
+++ b/tests/test_app/view/game/test_value_previous_games.py
@@ -5,7 +5,7 @@ from tests.helpers import GameFactory
 
 
 class ValuePreviousGamesTest(WebTest):
-    endpoint = '/game/value_previous_games/'
+    endpoint = '/game/test_lotto1/value_previous_games/'
 
     def setUp(self):
         super(ValuePreviousGamesTest, self).setUp()
@@ -14,9 +14,8 @@ class ValuePreviousGamesTest(WebTest):
         self.game_factory = GameFactory(amount_games=5, in_order_numbers=True)
         params = {'how_numbers': 45,
                   'previous_games': 5,
-                  'current_game': 5
                   }
-        resp = self.app.get(self.endpoint, params=params)
+        resp = self.app.get(f'{self.endpoint}5/', params=params)
         assert_that(resp.json, has_length(90))
         expected_result = {str(i): 5 for i in range(1, 46)}
         expected_result.update({str(i): 0 for i in range(46, 91)})
@@ -24,10 +23,8 @@ class ValuePreviousGamesTest(WebTest):
 
     def test_happy_path_without_how_numbers(self):
         self.game_factory = GameFactory(amount_games=5)
-        params = {'previous_games': 3,
-                  'current_game': 5
-                  }
-        resp = self.app.get(self.endpoint, params=params)
+        params = {'previous_games': 3}
+        resp = self.app.get(f'{self.endpoint}5/', params=params)
         expected_result = {str(i): 3 for i in range(1, 61)}
         expected_result.update({str(i): 0 for i in range(61, 91)})
         assert_that(resp.json, has_length(90))
@@ -36,4 +33,5 @@ class ValuePreviousGamesTest(WebTest):
 
     def test_validate_not_params(self):
         self.game_factory = GameFactory(amount_games=5)
-        assert_that(calling(self.app.get).with_args(self.endpoint, params={}), raises(TypeError))
+        assert_that(calling(self.app.get).with_args(f'{self.endpoint}5/', params={}),
+                    raises(TypeError))

--- a/tests/test_app/view/game/test_value_previous_games.py
+++ b/tests/test_app/view/game/test_value_previous_games.py
@@ -5,7 +5,7 @@ from tests.helpers import GameFactory
 
 
 class ValuePreviousGamesTest(WebTest):
-    endpoint = '/game/test_lotto1/value_previous_games/'
+    endpoint = '/test_lotto1/value_previous_games/'
 
     def setUp(self):
         super(ValuePreviousGamesTest, self).setUp()


### PR DESCRIPTION
lotto-38 Fixed created script: scripts/lotto-38_fix_name_game_study.py

lotto-38 Fixed POST {ng}game/parser/...

lotto-38 Fixed {ng}/research/{pk}/... endpoints.

lotto-38 Renamed {ng}/game/{pk}/last_games_info/ endpoind to {ng}/game/{pk}/several_games_info/. Fixed this endpoint.

lotto-38 Renamed {ng}/game/{pk}/index_bingo_30/ endpoind to {ng}/game/{pk}/future_game__30/. Fixed this endpoint.

lotto-38 Fixed {ng}/game/{pk}/info

lotto-38 Transformation the url routers. Now endpoint begin the prefix: .../{ng}/game/
Fixed tests.

lotto-38 Transformation the url routers. Now endpoint begin the prefix: .../game/{ng}/
Created lotto_app/app/views/value_previous_games.py file with ValuePreviousGamesViewSet viewset.
Fixed tests.