### PR TITLE
Lotto-41 comparison parts win ticket

### DIFF
--- a/lotto_app/app/models.py
+++ b/lotto_app/app/models.py
@@ -31,7 +31,7 @@ class Game(models.Model):
         """
         String for representing the Model object.
         """
-        return f'id: {self.id}, game: {self.game_id}'
+        return f'id: {self.id}, game_id: {self.game_id}'
 
     def save(self, *args, **kwargs):
         if not self.no_numbers:

--- a/lotto_app/app/views/games.py
+++ b/lotto_app/app/views/games.py
@@ -96,12 +96,12 @@ class GameViewSet(viewsets.ModelViewSet):
         good_games = int(request.query_params.get('good_games'))
         bad_games = int(request.query_params.get('bad_games'))
         game_id, game_obj = self.game_request()
-        total_cost_numbers = self.get_several_games_info(ng, game_id)['total_cost_numbers']
+        last_total_cost_numbers = self.get_several_games_info(ng, game_id-1)['total_cost_numbers']
         game_info = get_game_info(game_obj)
 
         indexes = {
-            'index_bingo': index_bingo(total_cost_numbers, game_info['bingo_30']),
-            'index_9_parts': index_9_parts(total_cost_numbers, game_info['bingo_30']),
+            'current_index_bingo': index_bingo(last_total_cost_numbers, game_info['bingo_30']),
+            'index_9_parts': index_9_parts(last_total_cost_numbers, game_info['bingo_30']),
             'good_numbers': self._get_good_numbers(game_id, good_games),
             'bad_numbers': self._get_bad_numbers(game_id, bad_games),
         }

--- a/lotto_app/app/views/researchs.py
+++ b/lotto_app/app/views/researchs.py
@@ -34,6 +34,46 @@ class ResearchViewSet(viewsets.ModelViewSet):
         resp.update(dict(sorted(dict_common_numbers.items(), key=lambda item: item[1], reverse=True)))
         return Response(resp, status=200)
 
+    @action(detail=True, url_path='comparison_parts_win_ticket', methods=['get'])
+    def comparison_parts_win_ticket(self, request, ng, pk=None):
+        main_game_obj = self.get_queryset().get(game_id=pk)
+
+        how_comparison_games = int(request.query_params.get('how_comparison_games'))
+        part_consists_of = int(request.query_params.get('part_consists_of'))
+        order_row = int(request.query_params.get('order_row'))
+
+        main_combination_win_ticket = main_game_obj.get_combination_win_ticket(part_consists_of, order_row)
+        main_numbers_in_row = []
+        for numbers in main_combination_win_ticket['numbers_in_row']:
+            main_numbers_in_row.extend(numbers)
+
+        comparison_games_objs = Game.objects.filter(
+            name_game=ng,
+            last_win_number_card__isnull=False,
+            last_win_number_ticket__isnull=False
+        ).annotate(
+            game_id_int=Cast('game_id', output_field=IntegerField())
+        ).filter(game_id_int__lte=int(pk)-1, game_id_int__gte=int(pk)-10-how_comparison_games
+                 ).order_by('-game_id_int')[0:how_comparison_games]
+
+        dict_comparisons = {_obj.game_id: [] for _obj in comparison_games_objs}
+        for _obj in comparison_games_objs:
+            _obj_combination_win_ticket = _obj.get_combination_win_ticket(part_consists_of, order_row)
+            _obj_numbers_in_row = []
+            for numbers in _obj_combination_win_ticket['numbers_in_row']:
+                _obj_numbers_in_row.extend(numbers)
+            for part in main_combination_win_ticket['parts']:
+                if part in _obj_combination_win_ticket['parts'] and not [
+                    number for number in part if number in _obj_numbers_in_row
+                ] and not [
+                    number for number in part if number in main_numbers_in_row
+                ]:
+                    dict_comparisons[_obj.game_id].append(part)
+
+        resp = {'main_game': pk}
+        resp.update(dict_comparisons)
+        return Response(resp, status=200)
+
     @action(detail=True, url_path='search_win_ticket', methods=['get'])
     def search_win_ticket(self, request, ng, pk=None):
         last_win_number_ticket = int(request.query_params.get('last_win_number_ticket', None))
@@ -76,7 +116,7 @@ class ResearchViewSet(viewsets.ModelViewSet):
         game_index_9_parts = {}
         for game_obj in game_objs:
             game_id = int(game_obj.game_id)
-            total_cost_numbers = GameViewSet.get_several_games_info(ng, game_id)['total_cost_numbers']
+            total_cost_numbers = GameViewSet.get_several_games_info(ng, game_id-1)['total_cost_numbers']
             game_info = get_game_info(game_obj)
             dict_no_numbers[game_id] = GameViewSet.get_several_games_no_numbers(
                 total_cost_numbers, game_info)

--- a/lotto_app/app/views/researchs.py
+++ b/lotto_app/app/views/researchs.py
@@ -17,8 +17,8 @@ class ResearchViewSet(viewsets.ModelViewSet):
     def get_game_obj(self):
         return Game.objects.get(game_id=self.kwargs['pk'])
 
-    @action(detail=True, url_path='combination_comparisons', methods=['get'])
-    def combination_comparisons(self, request, ng, pk=None):
+    @action(detail=True, url_path='comparison_win_ticket', methods=['get'])
+    def comparison_win_ticket(self, request, ng, pk=None):
         main_game_obj = self.get_queryset().get(game_id=pk)
 
         main_list_win_numbers = main_game_obj.numbers[:60]
@@ -30,7 +30,7 @@ class ResearchViewSet(viewsets.ModelViewSet):
                 set_common_numbers = set(main_list_win_numbers) & set(_comparison_list_win_numbers)
                 dict_common_numbers.update({_obj.game_id: [len(set_common_numbers), sorted(list(set_common_numbers))]})
 
-        resp = {'combination_comparisons': pk}
+        resp = {'main_game': pk}
         resp.update(dict(sorted(dict_common_numbers.items(), key=lambda item: item[1], reverse=True)))
         return Response(resp, status=200)
 

--- a/tests/test_app/view/test_game.py
+++ b/tests/test_app/view/test_game.py
@@ -217,13 +217,13 @@ class FutureGame30Test(WebTest):
         super(FutureGame30Test, self).setUp()
 
     def test_happy_path_future_game_30(self):
-        GameFactory(amount_games=3, in_order_numbers=True)
+        GameFactory(amount_games=4, in_order_numbers=True)
         params = {'good_games': 3,
                   'bad_games': 3}
-        resp = self.app.get(f'{self.endpoint}3/future_game_30/', params=params)
+        resp = self.app.get(f'{self.endpoint}4/future_game_30/', params=params)
         assert_that(list(resp.json.keys()),
-                    is_(['index_bingo', 'index_9_parts', 'good_numbers', 'bad_numbers']))
-        assert_that(resp.json['index_bingo'], is_(9480))
+                    is_(['current_index_bingo', 'index_9_parts', 'good_numbers', 'bad_numbers']))
+        assert_that(resp.json['current_index_bingo'], is_(9480))
         assert_that(resp.json['index_9_parts'],
                     is_({'0': 2, '1': 3, '2': 3, '3': 3, '4': 3, '5': 3, '6': 4, '7': 4, '8': 5}))
         assert_that(resp.json['good_numbers'],

--- a/tests/test_app/view/test_reasearch.py
+++ b/tests/test_app/view/test_reasearch.py
@@ -13,26 +13,26 @@ class GamesNoNumbersTest(WebTest):
         super(GamesNoNumbersTest, self).setUp()
 
     def test_validate_not_enough_games(self):
-        self.game_factory = GameFactory(amount_games=2)
+        self.game_factory = GameFactory(amount_games=3)
         params = {'how_games': 1}
-        assert_that(calling(self.app.get).with_args(f'{self.endpoint}2/games_no_numbers/', params=params),
-                    raises(IndexError))
         assert_that(calling(self.app.get).with_args(f'{self.endpoint}3/games_no_numbers/', params=params),
+                    raises(IndexError))
+        assert_that(calling(self.app.get).with_args(f'{self.endpoint}4/games_no_numbers/', params=params),
                     raises(AppError))
 
         self.game_factory = GameFactory(amount_games=1)
         # Now we have games and get result:
-        resp = self.app.get(f'{self.endpoint}3/games_no_numbers/', params=params)
-        assert_that(list(resp.json.keys()), is_(['3', 'all_no_numbers_9_parts']))
+        resp = self.app.get(f'{self.endpoint}4/games_no_numbers/', params=params)
+        assert_that(list(resp.json.keys()), is_(['4', 'all_no_numbers_9_parts']))
 
     def test_happy_path_games_no_numbers(self):
         self.game_factory = GameFactory(amount_games=5)
-        params = {'how_games': 3}
+        params = {'how_games': 2}
         resp = self.app.get(f'{self.endpoint}5/games_no_numbers/', params=params)
-        assert_that(list(resp.json.keys()), is_(['5', '4', '3', 'all_no_numbers_9_parts']))
+        assert_that(list(resp.json.keys()), is_(['5', '4', 'all_no_numbers_9_parts']))
 
     def test_happy_path_without_field_last_wins(self):
-        GameFactory(amount_games=3, in_order_numbers=True)
+        GameFactory(amount_games=4, in_order_numbers=True)
         _fields_games = GameFactory(amount_games=1,
                                     no_numbers_in_lotto=2,
                                     only_games_json=True).get_game_json()
@@ -44,8 +44,64 @@ class GamesNoNumbersTest(WebTest):
                         'no_numbers': _fields_games['no_numbers']
                     }])
         GameFactory(amount_games=1, in_order_numbers=True)
-        assert_that(Game.objects.count(), is_(5))
+        assert_that(Game.objects.count(), is_(6))
 
         params = {'how_games': 2}
-        resp = self.app.get(f'{self.endpoint}5/games_no_numbers/', params=params)
-        assert_that(list(resp.json.keys()), is_(['5', '3', 'all_no_numbers_9_parts']))
+        resp = self.app.get(f'{self.endpoint}6/games_no_numbers/', params=params)
+        assert_that(list(resp.json.keys()), is_(['6', '4', 'all_no_numbers_9_parts']))
+
+
+class ComparisonPartsWinTicketTest(WebTest):
+
+    numbers_1 = [61, 55, 7, 59, 63, 13, 49, 10, 48, 8, 22, 76, 39, 47, 75, 31, 23, 33, 87,
+                 77, 20, 44, 53, 43, 6, 18, 80, 58, 28, 62, 16, 78, 84, 21, 67, 89, 90, 36,
+                 79, 56, 54, 68, 46, 66, 12, 51, 72, 14, 50, 42, 17, 37, 38, 11, 64, 32, 1,
+                 81, 60, 70, 41, 2, 30, 74, 52, 24, 57, 40, 15, 4, 85, 5, 34, 71, 9, 82, 35,
+                 25, 86, 27, 73, 83, 3, 29, 88, 69, 65]
+
+    numbers_2 = [60, 89, 4, 44, 36, 57, 47, 21, 62, 51, 26, 63, 29, 66, 85, 84, 17, 23, 55,
+                 72, 11, 35, 67, 79, 32, 86, 5, 38, 16, 48, 33, 45, 80, 15, 88, 27, 74, 9, 49,
+                 46, 40, 58, 70, 14, 37, 56, 71, 77, 83, 28, 8, 81, 34, 78, 31, 43, 68, 59,
+                 87, 73, 64, 1, 42, 61, 25, 18, 39, 41, 20, 75, 54, 2, 10, 6, 50, 22, 12, 90,
+                 30, 3, 53, 24, 13, 82, 69, 52, 65]
+
+    numbers_3 = [58, 80, 72, 59, 23, 61, 70, 71, 75, 65, 82, 37, 47, 79, 2, 16, 43, 5, 60,
+                 54, 19, 6, 44, 49, 78, 1, 34, 11, 14, 90, 88, 36, 27, 87, 10, 69, 73, 32,
+                 17, 35, 55, 50, 20, 13, 8, 76, 25, 68, 45, 12, 64, 74, 51, 42, 26, 85, 28,
+                 52, 30, 31, 41, 7, 86, 22, 46, 39, 89, 77, 84, 66, 81, 4, 29, 15, 9, 57, 18,
+                 3, 21, 83, 48, 24, 53, 56, 38, 63, 33]
+
+    def _get_endpoint(self, game_id):
+        return f'/test_lotto1/research/{game_id}/comparison_parts_win_ticket/'
+
+    def _get_fields_games(self, numbers, game_id):
+        return [
+            {'name_game': 'test_lotto1',
+             'game_id': game_id,
+             'numbers': numbers,
+             'last_win_number_card': numbers[36],
+             'last_win_number_ticket': numbers[61]
+             }
+        ]
+
+    def test_happy_path_comparison_parts_win_ticket(self):
+        game_factory = [GameFactory(fields_games=self._get_fields_games(self.numbers_1, 1))]
+        game_factory.append(GameFactory(amount_games=1, in_order_numbers=True))
+        game_factory.append(GameFactory(fields_games=self._get_fields_games(self.numbers_2, 3)))
+        game_factory.append(GameFactory(amount_games=1, in_order_numbers=True))
+        game_factory.append(GameFactory(fields_games=self._get_fields_games(self.numbers_3, 5)))
+        params = {'how_comparison_games': 4,
+                  'part_consists_of': 5,
+                  'order_row': 8,
+                  }
+
+        resp = self.app.get(self._get_endpoint(5), params=params)
+
+        assert_that(list(resp.json.keys()), is_(['main_game', '4', '3', '2', '1']))
+        assert_that(resp.json['main_game'], is_('5'))
+        assert_that(resp.json['2'], is_([]))
+        assert_that(resp.json['4'], is_([]))
+        assert_that(resp.json['3'], is_([]))
+        assert_that(resp.json['1'], is_([[6, 7, 8, 10, 11], [7, 8, 10, 11, 12],
+                                         [8, 10, 11, 12, 13], [10, 11, 12, 13, 14],
+                                         [11, 12, 13, 14, 16], [12, 13, 14, 16, 17]]))


### PR DESCRIPTION
lotto-41: 
Renamed endpoint {ng}/research/{pk}/combination_comparisons/ to {ng}/research/{pk}/comparison_win_ticket/

lotto-41: Created the /{ng}/research/{pk}/comparison_parts_win_ticket/{format} endpoint and tests for this endpoint.
Fixed /{ng}/game/{pk}/future_game_30/ endpoint and FutureGame30Test class.