### PR TITLE
Lotto-43 Add 9_parts to_several_games_info endpoint

### DIFF
--- a/lotto_app/app/utils.py
+++ b/lotto_app/app/utils.py
@@ -84,6 +84,13 @@ def index_9_parts(cost_numbers, bingo):
     return dict((x, y) for x, y in sorted(sum_9_parts.items(), key=lambda x: x[0]))
 
 
+def get_9_parts_numbers(sorted_cost_numbers):
+    _9_parts_numbers = {}
+    for i in range(0, 9):
+        _9_parts_numbers[i] = list(sorted_cost_numbers.keys())[i*10: i*10+10]
+    return _9_parts_numbers
+
+
 def get_game_info(game_obj, mult=None):
     if not mult:
         mult = 1

--- a/lotto_app/app/views/games.py
+++ b/lotto_app/app/views/games.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 from lotto_app.app.models import Game
 from lotto_app.app.parsers.choise_parsers import ChoiseParsers
 from lotto_app.app.serializers import GameSerializer
-from lotto_app.app.utils import get_game_info, index_9_parts, index_bingo
+from lotto_app.app.utils import get_9_parts_numbers, get_game_info, index_9_parts, index_bingo
 from lotto_app.app.views.value_previous_games import ValuePreviousGamesViewSet
 from lotto_app.config import get_amount_games, get_factor_games
 
@@ -55,6 +55,7 @@ class GameViewSet(viewsets.ModelViewSet):
             'min_cost': str_total_cost_numbers[0],
             'max_cost': str_total_cost_numbers[89],
             'total_cost_numbers': total_cost_numbers,
+            '9_parts_numbers': get_9_parts_numbers(total_cost_numbers)
         }
 
     @staticmethod

--- a/tests/test_app/view/test_game.py
+++ b/tests/test_app/view/test_game.py
@@ -161,7 +161,7 @@ class GetSeveralGamesInfoTest(TestCase):
         return {
             'min_cost': {88: 0},
             'max_cost': {1: 540},
-            'total_cost_numbers': total_cost_numbers
+            'total_cost_numbers': total_cost_numbers,
         }
 
     def test_validate_not_enough_games(self):
@@ -180,7 +180,7 @@ class GetSeveralGamesInfoTest(TestCase):
         GameFactory(amount_games=1)
         assert_that(Game.objects.count(), is_(3))
         assert_that(list(GameViewSet.get_several_games_info('test_lotto1', 3).keys()),
-                    is_(['min_cost', 'max_cost', 'total_cost_numbers']))
+                    is_(['min_cost', 'max_cost', 'total_cost_numbers', '9_parts_numbers']))
 
     def test_happy_path_get_several_games_info(self):
         GameFactory(amount_games=3, in_order_numbers=True)
@@ -190,6 +190,16 @@ class GetSeveralGamesInfoTest(TestCase):
         assert_that(info['min_cost'], is_(expected_resp['min_cost']))
         assert_that(info['max_cost'], is_(expected_resp['max_cost']))
         assert_that(info['total_cost_numbers'], is_(expected_resp['total_cost_numbers']))
+        assert_that(info['9_parts_numbers'],
+                    is_({0: [88, 89, 90, 87, 86, 85, 84, 83, 82, 81],
+                         1: [80, 79, 78, 77, 76, 75, 74, 73, 72, 71],
+                         2: [70, 69, 68, 67, 66, 65, 64, 63, 62, 61],
+                         3: [60, 59, 58, 57, 56, 55, 54, 53, 52, 51],
+                         4: [50, 49, 48, 47, 46, 45, 44, 43, 42, 41],
+                         5: [40, 39, 38, 37, 36, 35, 34, 33, 32, 31],
+                         6: [30, 29, 28, 27, 26, 25, 24, 23, 22, 21],
+                         7: [20, 19, 18, 17, 16, 15, 14, 13, 12, 11],
+                         8: [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]}))
 
     def test_happy_path_without_field_last_wins(self):
         GameFactory(amount_games=2, in_order_numbers=True)


### PR DESCRIPTION
**9_parts_numbers** key added to **/{ng}/game/{pk}/several_games_info/** endpoint.
Fixed GetSeveralGamesInfoTest.test_happy_path_get_several_games_info test.
Created get_9_parts_numbers() function to the lotto_app/app/utils.py file.